### PR TITLE
fix(service/resource,service/gateway): Incorrect conversion between integer types.

### DIFF
--- a/service/gateway/middleware/transcoder/transcoder.go
+++ b/service/gateway/middleware/transcoder/transcoder.go
@@ -79,7 +79,7 @@ func Middleware(c *config.Middleware) (gtmiddleware.Middleware, error) {
 			resp.Trailer = nil
 			resp.Header.Set("Content-Type", contentType)
 			if grpcStatus := resp.Header.Get("grpc-status"); grpcStatus != "0" {
-				code, err := strconv.ParseInt(grpcStatus, 10, 64)
+				code, err := strconv.ParseInt(grpcStatus, 10, 32)
 				if err != nil {
 					return nil, err
 				}

--- a/service/resource/internal/app/file.go
+++ b/service/resource/internal/app/file.go
@@ -190,7 +190,7 @@ func (s *File) Upload() http.HandlerFunc {
 		if err != nil {
 			return errors.UploadFileErrorWrap(err)
 		}
-		if in.UploadId == "" || int(in.Index) <= 0 || len(in.Data) == 0 {
+		if in.UploadId == "" || in.Index == 0 || len(in.Data) == 0 {
 			return errors.ParamsError()
 		}
 


### PR DESCRIPTION
This PR addresses two issues with type conversions:

int64 to int32: The previous code attempted to convert an int64 value to int32, which could result in overflow.
uint32 to signed int: The code also tried to convert an unsigned uint32 value to a signed int, which may lead to incorrect behavior if the value exceeds the range of a signed integer.
Both issues have been resolved to ensure correct and safe type conversions.

Fixes: #5, #4